### PR TITLE
Use the right configuration option for inline sourcemaps

### DIFF
--- a/src/collections/_documentation/platforms/node/typescript.md
+++ b/src/collections/_documentation/platforms/node/typescript.md
@@ -43,7 +43,7 @@ Create a new one called _tsconfig.production.json_ and paste the snippet below:
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "sourceMap": true,
+    "inlineSourceMap": true,
     "inlineSources": true,
     "sourceRoot": "/"
   }


### PR DESCRIPTION
Using the current settings I had source map files generated separately. Changing the `sourceMap` option to `inlineSourceMap` made it work.